### PR TITLE
Squashed the bug

### DIFF
--- a/src/main/java/tourism/controllers/TouristController.java
+++ b/src/main/java/tourism/controllers/TouristController.java
@@ -57,9 +57,10 @@ public class TouristController {
     }
 
 
+    //TODO add PUT mapping instead. Could not get it to work without adding WebConfig file to change the post to put via the form on thymeleaf, which seems out of scope
     @PostMapping("/update")
-    public String updateAttraction(@ModelAttribute TouristAttraction touristAttraction){
-        touristService.updateAttraction(touristAttraction);
+    public String updateAttraction(@ModelAttribute TouristAttraction touristAttraction, @RequestParam("originalName") String originalName){
+        touristService.updateAttraction(touristAttraction, originalName);
         return "redirect:/attractions";
     }
 

--- a/src/main/java/tourism/repository/TouristRepository.java
+++ b/src/main/java/tourism/repository/TouristRepository.java
@@ -42,14 +42,16 @@ public class TouristRepository {
         return touristAttraction;
     }
 
-    public TouristAttraction updateAttraction(TouristAttraction touristAttraction) {
+    public TouristAttraction updateAttraction(TouristAttraction touristAttraction, String originalName) {
         for (TouristAttraction t : touristAttractions) {
+            if (t.getName().equals(originalName)) {
                 t.setName(touristAttraction.getName());
                 t.setDescription(touristAttraction.getDescription());
                 t.setTags(touristAttraction.getTags());
                 t.setCity(touristAttraction.getCity());
                 return t;
             }
+        }
         return null;
     }
 

--- a/src/main/java/tourism/service/TouristService.java
+++ b/src/main/java/tourism/service/TouristService.java
@@ -28,8 +28,8 @@ public class TouristService {
         return touristRepository.addAttraction(touristAttraction);
     }
 
-    public TouristAttraction updateAttraction(TouristAttraction touristAttraction) {
-        return touristRepository.updateAttraction(touristAttraction);
+    public TouristAttraction updateAttraction(TouristAttraction touristAttraction, String originalName) {
+        return touristRepository.updateAttraction(touristAttraction, originalName);
     }
 
     public TouristAttraction editAttraction(String name){

--- a/src/main/resources/templates/editAttraction.html
+++ b/src/main/resources/templates/editAttraction.html
@@ -8,8 +8,10 @@
 
 <form th:object="${touristAttraction}" th:action="@{/attractions/update}" method="post">
 
+
     <label for="attraction">Enter Attraction</label>
     <input type="text" id="attraction" name="name" th:value="${touristAttraction.getName()}">
+    <input type="hidden" name="originalName" th:value="${touristAttraction.name}" />
 
     <label for="description">Enter Description</label>
     <input type="text" id="description" name="description" th:value="${touristAttraction.getDescription()}">


### PR DESCRIPTION
**Issue:** 
Just found a annoying bug - if you edit any one attraction that is not the first, it then overwrites the first item in the table and does nothing for the one you wanted to edit , super wierd- I am currently bug hunting the issue

**First approach**
Tried to change the Post to PUT, but found out i needed a webConfig file in order to use the _method hidden field, as GET and POST are the only native solutions.

**Tried another approach:**
I knew that the issue was due to the POST method in the repo, as i had prev struggled with validating the IF statement. But just hoped for the best - this obviously bit me in the ass, so i had to come up with a solution where you can validate the name from the POST method, with the getName in the Arraylist, AND also be able to change the name that you are trying to validate. 

As the docs says we cannot use a UUID, (which is weird but whatever) I added a StrIng paramater to the post /update method, so in my repo method i can hold that up with the value i had before. This worked and we are now able to change the name also.
So it should be good to go now. I hope we are allowed to do UUID as that would have been simpler lol.